### PR TITLE
Distr_modeler class updated to handle different type of distribution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,9 @@ set_property(CACHE THRUST_DEVICE_SYSTEM PROPERTY STRINGS "CUDA;TBB;OPENMP;CPP")
 ###
 
 # VTK integration
-
 find_package(VTK)
 include (${VTK_USE_FILE})
 list(APPEND LINK_LIBS ${VTK_LIBRARIES})
-
 
 
 # Tell the compiler to use C++11, if not using Visual Studio.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ cmake_minimum_required (VERSION 2.8)
 project (edda)
 
 ### Provide options that the user can optionally select.
+option (EDDA_BUILD_MODELING "Build distribution modeling tools." OFF)
 option (EDDA_BUILD_VIS "Build distribution vis tools." OFF)
 
 option (EDDA_BUILD_TESTS "Build the test programs." OFF)

--- a/distr_modeler/exampleLoader.cpp
+++ b/distr_modeler/exampleLoader.cpp
@@ -13,14 +13,14 @@ using namespace edda;
 
 int main(int argc, char* argv[])
 {
-  DistrModeler<dist::DefaultGaussianMixture> dm(GMM);
+  DistrModeler dm(GMM);
   cout << dm.getType() << endl;
 
   //loading a netCDF ensemble file with dimension and variable names.
   dm.loader("/media/WD3/oceanEnsemble/pe_dif_sep2_98.nc", "tlat", "tlon", "outlev", "time", "temp");
 
   //cout << "distribution at location {45,26,10}: " <<  dm.getDistributionAt(45,26,10) << endl;
-  //dm.writer()//TODO: write to .vti files.
+  dm.writeToVTK("tempEns.vti","tempEns_");//TODO: write to .vti files.
 
     
   return 0;

--- a/src/common.h
+++ b/src/common.h
@@ -32,7 +32,7 @@ typedef float Real;
 
 // You can add more for needed return status
 enum ReturnStatus { SUCCESS = 0, FAIL, OUT_OF_BOUND };
-enum DistrType { GMM, HIST, HYBRID};
+enum DistrType { GMM, GMM1, GMM2, GMM3, GMM4, GMM5, HIST, HYBRID};
 
 
 #ifdef OS_WIN


### PR DESCRIPTION
1.Distr_Modeler is no longer a template class
2.created template member functions to handle different types of distributions GMM/GMM2/GMM3/GMM4/GMM5 etc.
3.Integrated the edda VTK writer.